### PR TITLE
Um link estava quebrado corrigi

### DIFF
--- a/wiki/readme.md
+++ b/wiki/readme.md
@@ -1,3 +1,3 @@
 # Páginas da wiki
 
-* [Projetos open-source](../../../blob/down-of-the-wiki/wiki/Projetos-open-source.md)
+* [Projetos open-source](Projetos-open-source.md)


### PR DESCRIPTION
O link da `wiki/readme.md` estava quebrado, corrigi ele para apontar no lugar correto